### PR TITLE
[develop] fix: copy yaml template files with pip installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,5 +12,11 @@ RUN conda run -n aqm-eval bash -c "pip install --no-deps . && pip list"
 RUN conda run -n aqm-eval bash -c "aqm-data-sync --help"
 RUN conda run -n aqm-eval bash -c "aqm-mm-eval --help"
 
+# Test that the yaml_template directory exists after pip installation
+RUN test -d /opt/conda/envs/aqm-eval/lib/python3.11/site-packages/aqm_eval/mm_eval/yaml_template
+
 WORKDIR /opt
 RUN rm -rf /opt/build
+
+# Activate environment by default
+RUN echo "conda activate aqm-eval" >> ~/.bashrc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ authors = [
 aqm-data-sync = "aqm_eval.data_sync.data_sync_cli:app"
 aqm-mm-eval = "aqm_eval.mm_eval.mm_eval_cli:app"
 
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.setuptools.package-data]
+"aqm_eval.mm_eval" = ["yaml_template/**/*"]
+
 [tool.ruff]
 line-length = 132
 


### PR DESCRIPTION
* `yaml_template` files were not appropriately copied when performing an installation.
* Updates `pyproject.toml` to copy over the files.
* Adds a test that the files are copied to the `Dockerfile`.